### PR TITLE
Update config

### DIFF
--- a/config
+++ b/config
@@ -77,8 +77,8 @@ access_token = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 access_token_secret = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 [flightaware]
-; FlightAware API allows to get more information about the flights. The personal tier is free,
-; and if you are a FlightAware feeder, you receive $10 of Per-Query fees free each month. For more 
+; FlightAware API provides additional information about flights. The personal tier is free, and
+; if you are a FlightAware feeder, you receive $10 of Per-Query fees free each month. For more 
 ; details: https://flightaware.com/commercial/aeroapi/#compare-plans-section
 fa_enable = False
 fa_username = XXXXXXXX

--- a/config
+++ b/config
@@ -35,7 +35,7 @@ image_height = 720
 ;    az             | Azimuth angle at the minimum distance.
 ;    heading        | Heading of aircraft at the minimum distance displayed as N, NW, W, SW, S, SE, E, or NE.
 ;    speed_mph      | Speed of the aircraft at the minimum distance in mi/h.
-;    speed_k     | Speed of the aircraft at the minimum distance in km/h.
+;    speed_kmph     | Speed of the aircraft at the minimum distance in km/h.
 ;    speed_kts      | Speed of the aircraft at the minimum distance in knots.
 ;    time           | Time when the aircraft is at the minimum distance.
 ;    rssi           | Signal strength in dB at the minimum distance.

--- a/config
+++ b/config
@@ -2,6 +2,7 @@
 driver = dump1090
 data_url = http://localhost/tar1090/data/aircraft.json
 map_url = http://localhost/tar1090/
+map_parameters = None
 request_timeout = 60
 
 ; An airplane is only tracked and tweeted when it enters the "alarm area" the alarm area
@@ -34,7 +35,7 @@ image_height = 720
 ;    az             | Azimuth angle at the minimum distance.
 ;    heading        | Heading of aircraft at the minimum distance displayed as N, NW, W, SW, S, SE, E, or NE.
 ;    speed_mph      | Speed of the aircraft at the minimum distance in mi/h.
-;    speed_kmph     | Speed of the aircraft at the minimum distance in km/h.
+;    speed_k     | Speed of the aircraft at the minimum distance in km/h.
 ;    speed_kts      | Speed of the aircraft at the minimum distance in knots.
 ;    time           | Time when the aircraft is at the minimum distance.
 ;    rssi           | Signal strength in dB at the minimum distance.
@@ -76,9 +77,9 @@ access_token = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 access_token_secret = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 [flightaware]
-; FlightAware API allows to get more information on the flights. Basic API access is now free
-; and if you are FA feeder, your request limit is doubled. For more details check:
-; https://flightaware.com/commercial/flightxml/pricing_class.rvt
+; FlightAware API allows to get more information about the flights. The personal tier is free,
+; and if you are a FlightAware feeder, you receive $10 of Per-Query fees free each month. For more 
+; details: https://flightaware.com/commercial/aeroapi/#compare-plans-section
 fa_enable = False
 fa_username = XXXXXXXX
 fa_api_key = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX


### PR DESCRIPTION
The map_parameters property is missing from config which causes an error when the config file is parsed. This adds the missing parameter and sets its value to null to resolve the error.

The text for the FlightAware API section has been updated as well to reflect the new FlightAware AeroAPI.