### PR TITLE
Add logic for nohup.out deletion to runbot.sh

### DIFF
--- a/runbot.sh
+++ b/runbot.sh
@@ -1,3 +1,14 @@
-rm nohup.out
-#nohup ./run_tracker.sh &
-nohup ./run_tracker.sh </dev/null >/dev/null 2>&1 &
+# Set nohup to 1 to write to nohup
+nohup=0
+
+if [[ -f nohup.out ]]
+then 
+    rm nohup.out
+fi
+
+if [ $nohup == 1 ]
+then
+    nohup ./run_tracker.sh &
+else
+    nohup ./run_tracker.sh </dev/null >/dev/null 2>&1 &
+fi


### PR DESCRIPTION
The runbot.sh script attempts to remove nohup.out without checking whether it exists first which can cause a warning/error.
This change adds logic to only attempt to delete the file if it exists.

Also adds a variable that can be used to indicate if nohup.out is desired without having to comment/uncomment lines.