### PR TITLE
Update flightdata.py

### DIFF
--- a/flightdata.py
+++ b/flightdata.py
@@ -201,6 +201,8 @@ class Dump1090DataParser(AircraftDataParser):
             speed = 0
             if "speed" in a:
                 speed = geomath.knot2mph(a["speed"])
+            if "gs" in a:
+                speed = geomath.knot2mph(a["gs"])
             if "mach" in a:
                 speed = geomath.mach2mph(a["mach"])
 


### PR DESCRIPTION
The original code is looking for "speed" in the aircraft.json file, but dump1090-fa uses "gs" (ground speed) instead. Added check for "gs" to allow speed to be reported for dump1090-fa users.

This same fix was submitted to OverPutney by derektgardner (Update flightdata.py #9)